### PR TITLE
refractor(movie): decouple movie deletion functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PROJECT_SOURCES
     src/utils/menu.c
     src/utils/input_utils.c
     src/utils/csv_utils.c
+    src/utils/decision_utils.c
     src/repos/movie_repo.c
     src/repos/screening_repo.c
     src/repos/ticket_repo.c

--- a/include/repos/movie_repo.h
+++ b/include/repos/movie_repo.h
@@ -10,3 +10,11 @@
  * @return pointer to MovieArray containing all movies or `NULL` if an error occurs
  */
 MovieArray *get_all_movies(const char *movie_source_path);
+
+/**
+ * @brief Delete a movie record from the system
+ * @param movie_id The ID of the movie to delete
+ * @param movie_source_path The file path for movies]
+ * @return pointer to the deleted Movie record or `NULL` if an error occurs
+ */
+Movie *delete_movie_record(int movie_id, const char *movie_source_path);

--- a/include/repos/screening_repo.h
+++ b/include/repos/screening_repo.h
@@ -9,4 +9,4 @@
  * @param screening_source_path The file path for screenings
  * @return pointer to ScreeningArray containing all screenings or `NULL` if an error occurs
  */
-ScreeningArray* get_all_screenings(const char *screening_source_path);
+ScreeningArray *get_all_screenings(const char *screening_source_path);

--- a/include/utils/decision_utils.h
+++ b/include/utils/decision_utils.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdio.h>
+
+/**
+ * @brief Prompts the user with a yes/no question and returns their decision
+ * @param prompt The question to present to the user
+ * @return `true` if the user responds with 'y' or 'Y', `false` otherwise
+ */
+bool is_decision_yes(const char *prompt);

--- a/src/repos/movie_repo.c
+++ b/src/repos/movie_repo.c
@@ -63,3 +63,81 @@ MovieArray *get_all_movies(const char *movie_source_path) {
 
     return movie_array;
 }
+
+
+Movie *delete_movie_record(int movie_id, const char *movie_source_path) {
+    FILE *movie_source = fopen(movie_source_path, "r");
+    if (movie_source == NULL) {
+        fprintf(stderr, "Failed to open movie source file: %s\n", movie_source_path);
+        return NULL;
+    }
+
+    char *last_slash = strrchr(movie_source_path, '/');
+#ifdef _WIN32
+    if (last_slash == NULL)
+        last_slash = strrchr(movie_source_path, '\\');
+#endif
+
+    char temp_file_path[256];
+    if (last_slash != NULL) {
+        size_t dir_length = last_slash - movie_source_path + 1;
+        strncpy(temp_file_path, movie_source_path, dir_length);
+        temp_file_path[dir_length] = '\0';
+        strcat(temp_file_path, "temp_movie.csv");
+    } else {
+        strncpy(temp_file_path, "temp_movie.csv", sizeof(temp_file_path) - 1);
+        temp_file_path[sizeof(temp_file_path) - 1] = '\0';
+    }
+
+    FILE *temp_file = fopen(temp_file_path, "w");
+    if (temp_file == NULL) {
+        fprintf(stderr, "Failed to create temporary file for movie deletion\n");
+        fclose(movie_source);
+        return NULL;
+    }
+
+    Movie *deleted_movie = NULL;
+
+    char buffer[LINE_DATA_BUFFER_SIZE];
+    fgets(buffer, LINE_DATA_BUFFER_SIZE, movie_source); // Read and write header line
+    fprintf(temp_file, "%s", buffer);
+
+    while (fgets(buffer, LINE_DATA_BUFFER_SIZE, movie_source)) {
+        char temp_buffer[LINE_DATA_BUFFER_SIZE];
+        strcpy(temp_buffer, buffer);
+
+        char *fields[N_MOVIES_FIELDS];
+        parse_csv_line(buffer, fields, N_MOVIES_FIELDS);
+
+        if (atoi(fields[0]) != movie_id) {
+            fprintf(temp_file, "%s", temp_buffer);
+        } else {
+            deleted_movie = (Movie *) malloc(sizeof(Movie));
+            if (deleted_movie == NULL) {
+                fprintf(stderr, "Memory allocation failed for deleted movie record\n");
+                fclose(movie_source);
+                fclose(temp_file);
+                return NULL;
+            }
+            deleted_movie->movie_id = atoi(fields[0]);
+            strncpy(deleted_movie->title, fields[1], sizeof(deleted_movie->title) - 1);
+            deleted_movie->title[sizeof(deleted_movie->title) - 1] = '\0';
+            deleted_movie->duration = atoi(fields[2]);
+        }
+    }
+
+    fclose(movie_source);
+    fclose(temp_file);
+
+    if (remove(movie_source_path) != 0) {
+        fprintf(stderr, "Failed to delete original movie source file: %s\n", movie_source_path);
+        return NULL;
+    }
+
+    if (rename(temp_file_path, movie_source_path) != 0) {
+        fprintf(stderr, "Failed to rename temporary file to original movie source file: %s\n", movie_source_path);
+        return NULL;
+    }
+
+    return deleted_movie;
+}

--- a/src/repos/screening_repo.c
+++ b/src/repos/screening_repo.c
@@ -4,6 +4,7 @@
 #include "../../include/utils/csv_utils.h"
 
 #include <ctype.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -64,4 +65,30 @@ ScreeningArray *get_all_screenings(const char *screening_source_path) {
 
     fclose(screening_source);
     return screening_array;
+}
+
+bool is_movie_scheduled(int target_movie_id, const char *screening_source_path) {
+    FILE *screening_source = fopen(screening_source_path, "r");
+    if (screening_source == NULL) {
+        fprintf(stderr, "Error opening screening source file: %s\n", screening_source_path);
+        return false;
+    }
+
+    char buffer[LINE_DATA_BUFFER_SIZE];
+    char *delimiter = ",";
+
+    fgets(buffer, LINE_DATA_BUFFER_SIZE, screening_source); // Skip the first row which contains the field names
+
+    while (fgets(buffer, LINE_DATA_BUFFER_SIZE, screening_source)) {
+        strtok(buffer, delimiter); // Skip the first column which is the screening ID
+        char *movie_id = strtok(NULL, delimiter);
+
+        if (atoi(movie_id) == target_movie_id) {
+            fclose(screening_source);
+            return true;
+        }
+    }
+
+    fclose(screening_source);
+    return false;
 }

--- a/src/services/movie_services.c
+++ b/src/services/movie_services.c
@@ -1,5 +1,8 @@
 #include "../../include/services/movie_services.h"
 #include "../../include/constanst.h"
+#include "../../include/repos/movie_repo.h"
+#include "../../include/repos/screening_repo.h"
+#include "../../include/utils/decision_utils.h"
 
 #include <ctype.h>
 #include <stdbool.h>
@@ -24,49 +27,14 @@ void edit_movie(int movie_id) {
 }
 
 /**
- * @brief Find the position of a movie in the movie source file
- * @param target_movie_id The ID of the movie to find
- * @param movie_source The file pointer to the movie source file
- * @return The line number of the movie if found, or `-1` if not found
+ * @brief Prints the details of a movie to the console
+ * @param movie Pointer to the Movie struct whose details are to be printed
  */
-static int find_movie_position(int target_movie_id, FILE *movie_source) {
-    char buffer[LINE_DATA_BUFFER_SIZE];
-    char *delimiter = ",";
-
-    fgets(buffer, LINE_DATA_BUFFER_SIZE, movie_source); // Skip the row of field names which is the first row
-    int current_line = 2;
-    while (fgets(buffer, LINE_DATA_BUFFER_SIZE, movie_source)) {
-        char *movie_id = strtok(buffer, delimiter);
-        if (atoi(movie_id) == target_movie_id)
-            return current_line;
-
-        current_line++;
-    }
-
-    return -1;
-}
-
-/**
- * @brief Check if a movie is scheduled for screening
- * @param target_movie_id The ID of the movie to check
- * @param screening_source The file pointer to the screening source file
- * @return `true` if the movie is scheduled, `false` otherwise
- */
-static bool is_movie_scheduled(int target_movie_id, FILE *screening_source) {
-    char buffer[LINE_DATA_BUFFER_SIZE];
-    char *delimiter = ",";
-
-    fgets(buffer, LINE_DATA_BUFFER_SIZE, screening_source); // Skip the first row which contains the field names
-
-    while (fgets(buffer, LINE_DATA_BUFFER_SIZE, screening_source)) {
-        strtok(buffer, delimiter); // Skip the first column which is the screening ID
-        char *movie_id = strtok(NULL, delimiter);
-
-        if (atoi(movie_id) == target_movie_id)
-            return true;
-    }
-
-    return false;
+static void print_movie_details(const Movie *movie) {
+    printf("Movie Details:\n");
+    printf("ID: %d\n", movie->movie_id);
+    printf("Title: %s\n", movie->title);
+    printf("Duration: %d minutes\n", movie->duration);
 }
 
 void delete_movie(int movie_id) {
@@ -75,67 +43,22 @@ void delete_movie(int movie_id) {
         return;
     }
 
-    FILE *movie_source = fopen("data/movie.csv", "r");
-
-    if (movie_source == NULL) {
-        printf("Cannot find the movie source\n");
-        return;
-    }
-
-    int movie_row_position = find_movie_position(movie_id, movie_source);
-    if (movie_row_position == -1) {
-        printf("The movie ID is not found!\n");
-        fclose(movie_source);
-        return;
-    }
-
-    bool is_scheduled;
-
-    FILE *screening_source = fopen("data/screening.csv", "r");
-    if (screening_source == NULL)
-        is_scheduled = true;
-    else
-        is_scheduled = is_movie_scheduled(movie_id, screening_source);
-
-    if (screening_source != NULL)
-        fclose(screening_source);
+    bool is_scheduled = is_movie_scheduled(movie_id, SCREENING_SOURCE_PATH);
 
     if (is_scheduled) {
-        printf("The movie is scheduled, please cancel related screenings before delete the movie!\n");
-        fclose(movie_source);
+        printf("The movie is scheduled, please cancel all related screenings before deleting the movie!\n");
         return;
     }
 
-    printf("Delete movie with ID %d [y/N(Default)]: ", movie_id);
-    char decision;
-    scanf("%c", &decision);
-    int c;
-    while ((c = getchar()) != '\n' && c != EOF)
-        ; // clear buffer
-    if (tolower(decision) != 'y') {
-        fclose(movie_source);
+    if (!is_decision_yes("Delete movie with ID"))
         return;
+
+    Movie *deleted_movie = delete_movie_record(movie_id, MOVIE_SOURCE_PATH);
+    if (deleted_movie != NULL) {
+        printf("Movie deleted successfully!\n");
+        print_movie_details(deleted_movie);
+        free(deleted_movie);
+    } else {
+        printf("Failed to delete the movie.\n");
     }
-
-    FILE *temp = fopen("temp.txt", "w");
-    char buffer[LINE_DATA_BUFFER_SIZE];
-
-    rewind(movie_source);
-
-    // Write the row (1st row) of the field names
-    fgets(buffer, LINE_DATA_BUFFER_SIZE, movie_source);
-    fputs(buffer, temp);
-    int current_line = 2;
-
-    while (fgets(buffer, LINE_DATA_BUFFER_SIZE, movie_source) != NULL) {
-        if (current_line != movie_row_position)
-            fputs(buffer, temp);
-        current_line++;
-    }
-
-    fclose(movie_source);
-    fclose(temp);
-
-    remove("data/movie.csv");
-    rename("temp.txt", "data/movie.csv");
 }

--- a/src/utils/decision_utils.c
+++ b/src/utils/decision_utils.c
@@ -1,0 +1,15 @@
+#include "../../include/utils/decision_utils.h"
+
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+bool is_decision_yes(const char *prompt) {
+    printf("%s [y/N(Default)]: ", prompt);
+    char decision;
+    scanf("%c", &decision);
+    int c;
+    while ((c = getchar()) != '\n' && c != EOF)
+        ; // clear buffer
+    return tolower(decision) == 'y';
+}


### PR DESCRIPTION
## Summary
This PR adds support for deleting movies from the system and prevents deletion when the movie is still referenced by existing screenings.

## What changed
- Added movie deletion flow in `movie_services`.
- Moved movie deletion persistence logic into `movie_repo`.
- Added screening check in `screening_repo` to detect whether a movie is scheduled
- Added reusable `decision_utils` for yes/no confirmation prompts
- Updated build configuration to include the new utility module

## Refactoring
- Reduced file-handling logic inside `movie_services`.
- Reused repository and utility layers to better separate service, repo, and input/decision responsibilities

## Related Issue
Issue #8