### PR TITLE
chore(git): ignore all compiled .exe files recursively and .vscode config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
-.vscode
+.vscode/
 dist
+**/*.exe


### PR DESCRIPTION
## Overview
This pull request configures the `.gitignore` file to automatically and recursively exclude all executable `.exe` files generated during the C project compilation process across the root directory and all subdirectories. Furthermore, it removes all personal configurations of VS Code

## Key Changes
- **Configure `.gitignore`**: Added the `**/*.exe`  and changed `.vscode` to `.vscode/` rule to block Git from tracking executable files at any directory depth.
- **Clean Git Cache**: Removed the tracked status of any `.exe` files previously committed to the repository without deleting the local physical files.
- **Additional Rules**: Added filtering for compiler-generated artifacts and IDE configurations to prevent workspace clutter.

## Why are these changes necessary?
- Prevents uploading heavy and redundant binary `.exe` files to the remote repository.
- Reduces the overall repository size, improving `git clone` and `git fetch` speeds for all team members.
- Avoids unnecessary merge conflicts caused by local build artifacts specific to each developer's machine.

