### PR TITLE
fix: change static buffer to dynamic allocation via function parameter

### DIFF
--- a/src/utils/input_utils.c
+++ b/src/utils/input_utils.c
@@ -28,7 +28,10 @@ static int handle_input_id(const char *user_input) {
 
 
 int input_id(const char *prompt, int buffer_size) {
-    char user_input[buffer_size];
+    char *user_input = (char *) malloc((size_t) buffer_size);
+    if (user_input == NULL)
+        return -1;
+
     printf("%s", prompt);
     fgets(user_input, buffer_size, stdin);
 
@@ -41,5 +44,7 @@ int input_id(const char *prompt, int buffer_size) {
             ;
     }
 
-    return handle_input_id(user_input);
+    int result = handle_input_id(user_input);
+    free(user_input);
+    return result;
 }


### PR DESCRIPTION
## Overview
This pull request fixes a runtime/compilation issue caused by using a function parameter to define a static array size. The static buffer has been replaced with dynamic memory allocation using malloc.

## Key Changes
- **Dynamic Allocation**: Changed user_input from a static char array to a dynamically allocated pointer using malloc based on the input buffer_size parameter.
- **Safety Verification**: Added a conditional check to ensure user_input is not NULL right after allocation, returning -1 immediately if the system runs out of memory.

## Why are these changes necessary?
- Standard C does not reliably support Variable Length Arrays (VLAs) inside functions when the size is passed as a variable parameter, which can cause compilation failures depending on the compiler settings.
- Static stack allocation with dynamic parameters risks stack overflow errors if a very large buffer_size value is provided. Moving to the heap ensures safer and more flexible memory management.