### PR TITLE
Add utility for generating temporary file paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(PROJECT_SOURCES
     src/utils/input_utils.c
     src/utils/csv_utils.c
     src/utils/decision_utils.c
+    src/utils/get_temp_file_path.c
     src/repos/movie_repo.c
     src/repos/screening_repo.c
     src/repos/ticket_repo.c

--- a/include/utils/get_temp_file_path.h
+++ b/include/utils/get_temp_file_path.h
@@ -1,0 +1,8 @@
+#pragma once
+
+/**
+ * @brief Generates a temporary file path based on the source file path
+ * @param original_path The path to the source file
+ * @return A pointer to the generated temporary file path
+ */
+char *get_temp_file_path(const char *original_path);

--- a/src/utils/get_temp_file_path.c
+++ b/src/utils/get_temp_file_path.c
@@ -1,0 +1,29 @@
+#include "../../include/utils/get_temp_file_path.h"
+#include "../../include/constanst.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char *get_temp_file_path(const char *original_path) {
+    if (original_path == NULL)
+        return NULL;
+
+    const char *last_slash = strrchr(original_path, '/');
+
+    size_t dir_len = (last_slash != NULL) ? (last_slash - original_path) + 1 : 0;
+
+    char *temp_path = (char *) malloc(dir_len + 8 + 1);
+    if (temp_path == NULL)
+        return NULL;
+
+    if (dir_len > 0) {
+        strncpy(temp_path, original_path, dir_len);
+        temp_path[dir_len] = '\0';
+    } else
+        temp_path[0] = '\0';
+
+    strcat(temp_path, "temp.csv");
+
+    return temp_path;
+}


### PR DESCRIPTION
## Description
This PR introduces a new utility function `get_temp_file_path` to handle the creation of temporary file paths during file editing operations. This ensures that original files remain untouched until the write operation is successfully completed, enhancing data integrity and atomicity.

## Changes
- Created `get_temp_file_path.h`: Header file defining the interface.
- Created `get_temp_file_path.c`: Implementation of path generation.