### PR TITLE
fix: add missing function declaration in screening_repo.h

### DIFF
--- a/include/repos/screening_repo.h
+++ b/include/repos/screening_repo.h
@@ -2,6 +2,7 @@
 
 #include "../models/screening.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 
 /**
@@ -10,3 +11,11 @@
  * @return pointer to ScreeningArray containing all screenings or `NULL` if an error occurs
  */
 ScreeningArray *get_all_screenings(const char *screening_source_path);
+
+/**
+ * @brief Check if a movie is scheduled for screening
+ * @param target_movie_id The ID of the movie to check
+ * @param screening_source_path The file path for screenings
+ * @return `true` if the movie is scheduled, `false` otherwise
+ */
+bool is_movie_scheduled(int target_movie_id, const char *screening_source_path);


### PR DESCRIPTION
## Context
This PR fixes a compilation issue where a function was implemented in `screening_repo.c` and utilized within the system, but its prototype was missing from the corresponding header file.
This caused "implicit declaration" warnings (or errors depending on compiler flags) and could lead to undefined behavior at runtime due to incorrect return type assumptions

## Changes
- **Update:** Added the missing function prototype to the interface in **`screening_repo.h`**