### PR TITLE
feat: implement screening cancellation and automatic ticket cleanup

### DIFF
--- a/include/constanst.h
+++ b/include/constanst.h
@@ -10,3 +10,7 @@
 #define N_MOVIES_FIELDS 3
 #define N_SCREENING_FIELDS 5
 #define N_TICKETS_FIELDS 4
+
+#define TEMP_FILE_NAME "temp_file.csv"
+
+#define DIR_LENGTH 256

--- a/include/repos/screening_repo.h
+++ b/include/repos/screening_repo.h
@@ -19,3 +19,11 @@ ScreeningArray *get_all_screenings(const char *screening_source_path);
  * @return `true` if the movie is scheduled, `false` otherwise
  */
 bool is_movie_scheduled(int target_movie_id, const char *screening_source_path);
+
+/**
+ * @brief Delete a screening record from the system
+ * @param screening_id The ID of the screening to delete
+ * @param screening_source_path The file path for screenings
+ * @return pointer to the deleted Screening or `NULL` if an error occurs
+ */
+Screening *delete_screening_record(int screening_id, const char *screening_source_path);

--- a/include/repos/ticket_repo.h
+++ b/include/repos/ticket_repo.h
@@ -10,3 +10,11 @@
  * @return pointer to TicketArray containing all retrieved tickets or `NULL` if an error occurs
  */
 TicketArray *get_all_tickets(const char *ticket_source_path);
+
+
+/**
+ * @brief Deletes a ticket with the specified ID from the source
+ * @param ticket_source_path The file path to the ticket source
+ * @param screening_id The ID of the screening for which to delete tickets
+ */
+void delete_ticket_record_by_screening_id(int screening_id, const char *ticket_source_path);

--- a/include/services/screening_services.h
+++ b/include/services/screening_services.h
@@ -19,5 +19,6 @@ void create_screening(int movie_id);
 
 /**
  * @brief Cancel an existing screening
+ * @param screening_id The ID of the screening to cancel
  */
-void cancel_screening();
+void cancel_screening(int screening_id);

--- a/src/repos/screening_repo.c
+++ b/src/repos/screening_repo.c
@@ -1,7 +1,7 @@
 #include "../../include/repos/screening_repo.h"
-
 #include "../../include/constanst.h"
 #include "../../include/utils/csv_utils.h"
+#include "../../include/utils/get_temp_file_path.h"
 
 #include <ctype.h>
 #include <stdbool.h>
@@ -91,4 +91,71 @@ bool is_movie_scheduled(int target_movie_id, const char *screening_source_path) 
 
     fclose(screening_source);
     return false;
+}
+
+Screening *delete_screening_record(int screening_id, const char *screening_source_path) {
+    FILE *screening_source = fopen(screening_source_path, "r");
+    if (screening_source == NULL) {
+        fprintf(stderr, "Failed to open screening source file: %s\n", screening_source_path);
+        return NULL;
+    }
+
+    char *temp_path = get_temp_file_path(screening_source_path);
+
+    FILE *temp_file = fopen(temp_path, "w");
+    if (temp_file == NULL) {
+        fprintf(stderr, "Failed to create temporary file for screening deletion\n");
+        fclose(screening_source);
+        free(temp_path);
+        return NULL;
+    }
+
+    Screening *deleted_screening = NULL;
+
+    char buffer[LINE_DATA_BUFFER_SIZE];
+    fgets(buffer, LINE_DATA_BUFFER_SIZE, screening_source); // Read and write header line
+    fprintf(temp_file, "%s", buffer);
+
+    while (fgets(buffer, LINE_DATA_BUFFER_SIZE, screening_source)) {
+        char temp_buffer[LINE_DATA_BUFFER_SIZE];
+        strcpy(temp_buffer, buffer);
+
+        char *fields[N_SCREENING_FIELDS];
+        parse_csv_line(buffer, fields, N_SCREENING_FIELDS);
+
+        if (atoi(fields[0]) != screening_id) {
+            fprintf(temp_file, "%s", temp_buffer);
+        } else {
+            deleted_screening = (Screening *) malloc(sizeof(Screening));
+            if (deleted_screening == NULL) {
+                fprintf(stderr, "Memory allocation failed for deleted screening record\n");
+                fclose(screening_source);
+                fclose(temp_file);
+                return NULL;
+            }
+            deleted_screening->screening_id = atoi(fields[0]);
+            deleted_screening->movie_id = atoi(fields[1]);
+            deleted_screening->start_time = (time_t) atol(fields[2]);
+            deleted_screening->price = atof(fields[3]);
+            deleted_screening->room_number = atoi(fields[4]);
+        }
+    }
+
+    fclose(screening_source);
+    fclose(temp_file);
+
+    if (remove(screening_source_path) != 0) {
+        fprintf(stderr, "Failed to delete original screening source file: %s\n", screening_source_path);
+        return NULL;
+    }
+
+    if (rename(temp_path, screening_source_path) != 0) {
+        fprintf(stderr, "Failed to rename temporary file to original screening source file: %s\n",
+                screening_source_path);
+        return NULL;
+    }
+
+    free(temp_path);
+
+    return deleted_screening;
 }

--- a/src/repos/ticket_repo.c
+++ b/src/repos/ticket_repo.c
@@ -1,6 +1,7 @@
 #include "../../include/repos/ticket_repo.h"
 #include "../../include/constanst.h"
 #include "../../include/utils/csv_utils.h"
+#include "../../include/utils/get_temp_file_path.h"
 
 #include <ctype.h>
 #include <stdio.h>
@@ -63,4 +64,46 @@ TicketArray *get_all_tickets(const char *ticket_source_path) {
 
     fclose(ticket_source);
     return ticket_array;
+}
+
+void delete_ticket_record_by_screening_id(int screening_id, const char *ticket_source_path) {
+    FILE *ticket_source = fopen(ticket_source_path, "r");
+    if (ticket_source == NULL) {
+        fprintf(stderr, "Failed to open ticket source file: %s\n", ticket_source_path);
+        return;
+    }
+
+    char *temp_path = get_temp_file_path(ticket_source_path);
+
+    FILE *temp_file = fopen(temp_path, "w");
+    if (temp_file == NULL) {
+        fprintf(stderr, "Failed to create temporary file for ticket deletion\n");
+        fclose(ticket_source);
+        free(temp_path);
+        return;
+    }
+
+    char buffer[LINE_DATA_BUFFER_SIZE];
+    fgets(buffer, LINE_DATA_BUFFER_SIZE, ticket_source); // Read and write header line
+    fprintf(temp_file, "%s", buffer);
+
+    while (fgets(buffer, LINE_DATA_BUFFER_SIZE, ticket_source)) {
+        char temp_buffer[LINE_DATA_BUFFER_SIZE];
+        strcpy(temp_buffer, buffer);
+
+        char *fields[N_TICKETS_FIELDS];
+        parse_csv_line(buffer, fields, N_TICKETS_FIELDS);
+
+        if (atoi(fields[1]) != screening_id) {
+            fprintf(temp_file, "%s", temp_buffer);
+        }
+    }
+
+    fclose(ticket_source);
+    fclose(temp_file);
+
+    remove(ticket_source_path);
+    rename(temp_path, ticket_source_path);
+
+    free(temp_path);
 }

--- a/src/services/screening_services.c
+++ b/src/services/screening_services.c
@@ -4,7 +4,9 @@
 #include "../../include/models/screening.h"
 #include "../../include/repos/movie_repo.h"
 #include "../../include/repos/screening_repo.h"
+#include "../../include/repos/ticket_repo.h"
 #include "../../include/utils/csv_utils.h"
+#include "../../include/utils/decision_utils.h"
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -99,6 +101,40 @@ void create_screening(int movie_id) {
     // TODO
 }
 
-void cancel_screening() {
-    // TODO
+/**
+ * @brief Print details about a screening
+ * @param screening The screening for which to print details
+ */
+static void print_screening_details(Screening *screening) {
+    printf("Screening Details:\n");
+    printf("ID: %d\n", screening->screening_id);
+    printf("Movie ID: %d\n", screening->movie_id);
+    char time_str[26];
+    strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", localtime(&screening->start_time));
+    printf("Start Time: %s\n", time_str);
+    printf("Price: %.0f VND\n", screening->price);
+    printf("Room Number: %d\n", screening->room_number);
+}
+
+void cancel_screening(int screening_id) {
+    if (screening_id == -1) {
+        printf("The ID is invalid!\n");
+        return;
+    }
+
+    if (!is_decision_yes("Cancel screening with ID"))
+        return;
+
+    delete_ticket_record_by_screening_id(screening_id, TICKET_SOURCE_PATH);
+
+    Screening *deleted_screening = delete_screening_record(screening_id, SCREENING_SOURCE_PATH);
+
+
+    if (deleted_screening != NULL) {
+        printf("Screening cancelled successfully!\n");
+        print_screening_details(deleted_screening);
+        free(deleted_screening);
+    } else {
+        printf("Failed to cancel the screening.\n");
+    }
 }


### PR DESCRIPTION
## Description
This PR implements the **Screening Cancellation** feature, which ensures data consistency by removing a screening and all its associated tickets.

## Changes
- **Constants & Core**: Updated `constants.h` with new definitions.
- **Repository Layer**: 
    - `screening_repo.h/c`: Added logic to remove screenings by ID from `screening.csv`.
    - `ticket_repo.h/c`: Added logic to batch delete all tickets matching a specific `screeningID` in `ticket.csv`.
- **Service Layer**: 
    - `screening_service.c`: Implemented the business logic to coordinate the deletion process and ensure atomicity.

## How to Test
1. Identify a `screeningID` in `screening.csv`.
2. Ensure there are multiple tickets associated with this ID in `ticket.csv`.
3. Run the "Cancel Screening" feature with that ID.
4. Verify that:
    - The record is removed from `screening.csv`.
    - All related records are removed from `ticket.csv`.

## Impacted Files
- `constants.h`
- `screening_repo.h` / `screening_repo.c`
- `ticket_repo.h` / `ticket_repo.c`
- `screening_service.c`

Closed #12 